### PR TITLE
fix: 禁止对deepin_unkillable_t 进程kill任何信号

### DIFF
--- a/debian/patches/initialize-usids-of-usec-policy.patch
+++ b/debian/patches/initialize-usids-of-usec-policy.patch
@@ -637,7 +637,7 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
 +	type deepin_unkillable_t;
 +	deepin_app_domain_set(deepin_unkillable_t);
 +	allow deepin_unkillable_t self:service *;
-+	allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill sigstop };
++	allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
 +	allow deepin_usec_t deepin_unkillable_t:service ~{ stop reload disable };
 +')
 \ No newline at end of file


### PR DESCRIPTION
     修复防杀进程deepin_unkillable_t 仍可以通过kill SIGTERM杀进程

     Bug: https://pms.uniontech.com/bug-view-302027.html
     Bug: https://pms.uniontech.com/bug-view-301947.html

Change-Id: I5d8eb1ad901cb598a26b7417ffaf9656e6606c31