### PR TITLE
fix: usec: 添加deepin_system_service_t允许其杀deepin_unkillable_t

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+refpolicy (2:2.20240723-2deepin15) unstable; urgency=medium
+
+  * fix: usec: 添加deepin_system_service_t允许其杀deepin_unkillable_t
+
+ -- zhangya <zhangya@uniontech.com>  Fri, 31 Oct 2025 10:36:49 +0800
+
 refpolicy (2:2.20240723-2deepin14) unstable; urgency=medium
 
   * fix: usec: 禁止apt,dpkg_t域转换到deepin_immutable

--- a/debian/patches/0001-fix-immutable.patch
+++ b/debian/patches/0001-fix-immutable.patch
@@ -29,25 +29,68 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
  allow deepin_security_server_domain self:key_socket *;
  allow deepin_security_server_domain self:filesystem *;
  allow deepin_security_server_domain self:system *;
-@@ -871,17 +875,18 @@ allow deepin_executable_file_type deepin
- ifdef(`enable_usec',`
- 	# umount管控
- 	require {
+@@ -868,31 +872,37 @@ allow deepin_home_sec_t self:filesystem
+ allow deepin_executable_file_type deepin_home_sec_t:file ~{ relabelfrom relabelto };
+ allow deepin_executable_file_type deepin_home_sec_t:dir list_dir_perms;
+ 
+-ifdef(`enable_usec',`
+-	# umount管控
+-	require {
 -		class filesystem unmount;
-+		class filesystem { unmount remount };
- 		type usec_immutable_fs_t;
- 		type deepin_perm_manager_sidtwo_t;
- 		class file execute;
- 	}
- 	type deepin_immutable_t, deepin_security_server_domain;
- 	deepin_app_domain_set(deepin_immutable_t);
+-		type usec_immutable_fs_t;
+-		type deepin_perm_manager_sidtwo_t;
+-		class file execute;
+-	}
+-	type deepin_immutable_t, deepin_security_server_domain;
+-	deepin_app_domain_set(deepin_immutable_t);
 -	allow deepin_immutable_t usec_immutable_fs_t:filesystem { unmount };
-+	allow deepin_immutable_t usec_immutable_fs_t:filesystem { unmount remount };
- 
- 	type_transition deepin_immutable_t deepin_usec_t:process deepin_immutable_t;
+-
+-	type_transition deepin_immutable_t deepin_usec_t:process deepin_immutable_t;
 -	allow deepin_perm_manager_sidtwo_t usec_immutable_fs_t:filesystem { unmount };
-+	allow deepin_perm_manager_sidtwo_t usec_immutable_fs_t:filesystem { unmount remount };
-+	neverallow { apt_t dpkg_t } deepin_immutable_t:process { transition dyntransition };
- ')
- 
+-')
+-
  # 系统核心进程防杀标签
+ ifdef(`enable_usec',`
+-	require {
+-		attribute deepin_executable_file_type;
+-	}
+-
+-	type deepin_unkillable_t;
+-	deepin_app_domain_set(deepin_unkillable_t);
+-	allow deepin_unkillable_t self:service *;
+-	allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
+-	allow deepin_usec_t deepin_unkillable_t:service ~{ stop reload disable };
+-')
+\ No newline at end of file
++        # umount管控
++        require {
++                class filesystem { unmount remount };
++                type usec_immutable_fs_t;
++                type deepin_perm_manager_sidtwo_t;
++        }
++        type deepin_immutable_t;
++        type deepin_unkillable_t;
++        type deepin_system_service_t;
++
++        deepin_app_domain_set(deepin_immutable_t);
++        allow deepin_immutable_t usec_immutable_fs_t:filesystem { unmount remount };
++
++        type_transition deepin_immutable_t deepin_usec_t:process deepin_immutable_t;
++        allow deepin_perm_manager_sidtwo_t usec_immutable_fs_t:filesystem { unmount remount };
++        neverallow { apt_t dpkg_t } deepin_immutable_t:process { transition dyntransition };
++
++
++        deepin_app_domain_set(deepin_unkillable_t);
++        allow deepin_unkillable_t self:service *;
++        allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
++        allow deepin_usec_t deepin_unkillable_t:service ~{ stop reload disable };
++
++        # 系统进程deepin_system_service_t，允许其杀deepin_unkillable_t防杀进程
++        # 例如lastrore-daemon结束系统升级,需要会杀死deepin_immutable_ctl来结束系统升级
++
++        deepin_app_domain_set(deepin_system_service_t);
++        allow deepin_system_service_t deepin_unkillable_t:process *;
++        allow deepin_system_service_t deepin_unkillable_t:service *;
++        allow deepin_system_service_t deepin_immutable_t:process *;
++        allow deepin_system_service_t deepin_immutable_t:service *;
++')


### PR DESCRIPTION
Change-Id: Iae4d08488cf3cfc93438a675da6ae8c3f375760a

## Summary by Sourcery

Allow deepin_system_service_t processes to kill deepin_unkillable_t processes by updating the SELinux policy in the Debian packaging.

Bug Fixes:
- Permit deepin_system_service_t to send kill signals to deepin_unkillable_t in the SELinux policy.

Chores:
- Update Debian changelog and apply corresponding patch to include the new policy rule.