### PR TITLE
fix: deepin_system_service_t kill dpkt_t/apt_t denied.

### DIFF
--- a/debian/patches/0001-fix-immutable.patch
+++ b/debian/patches/0001-fix-immutable.patch
@@ -16,8 +16,8 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
  		allow deepin_usec_t deepin_perm_manager_unit_t:service *;
  	')
 +
-+	allow deepin_usec_t apt_t:process  { ptrace signal sigkill sigstop };
-+	allow deepin_usec_t dpkg_t:process { ptrace signal sigkill sigstop };
++	allow deepin_usec_t apt_t:process *;
++	allow deepin_usec_t dpkg_t:process *;
  ')
  
  # 注意, 这里由deepin_perm_manager_unit_t 保证服务不被stop就能防止通过systemctl stop来杀安全服务了
@@ -29,7 +29,16 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
  allow deepin_security_server_domain self:key_socket *;
  allow deepin_security_server_domain self:filesystem *;
  allow deepin_security_server_domain self:system *;
-@@ -868,31 +872,37 @@ allow deepin_home_sec_t self:filesystem
+@@ -399,7 +403,7 @@ allow deepin_executable_file_type deepin
+ allow deepin_executable_file_type deepin_executable_file_type:socket_class_set ~{ relabelfrom relabelto };
+ allow deepin_executable_file_type deepin_executable_file_type:dir_file_class_set { mounton lock };
+ allow deepin_executable_file_type deepin_executable_file_type:filesystem { mount remount };
+-allow deepin_executable_file_type deepin_executable_file_type:service ~{ stop reload disable };
++allow deepin_executable_file_type deepin_executable_file_type:service ~{ stop disable };
+ 
+ allow deepin_executable_file_type self:file { exec_file_perms link execmod };
+ 
+@@ -868,31 +872,87 @@ allow deepin_home_sec_t self:filesystem
  allow deepin_executable_file_type deepin_home_sec_t:file ~{ relabelfrom relabelto };
  allow deepin_executable_file_type deepin_home_sec_t:dir list_dir_perms;
  
@@ -62,35 +71,85 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
 -	allow deepin_usec_t deepin_unkillable_t:service ~{ stop reload disable };
 -')
 \ No newline at end of file
-+        # umount管控
-+        require {
-+                class filesystem { unmount remount };
-+                type usec_immutable_fs_t;
-+                type deepin_perm_manager_sidtwo_t;
-+        }
-+        type deepin_immutable_t;
-+        type deepin_unkillable_t;
-+        type deepin_system_service_t;
++    # umount管控
++    require {
++        class filesystem { unmount remount };
++        type usec_immutable_fs_t;
++        type deepin_perm_manager_sidtwo_t;
++    }
++    type deepin_immutable_t;
++    type deepin_unkillable_t;
++    type deepin_system_service_t;
 +
-+        deepin_app_domain_set(deepin_immutable_t);
-+        allow deepin_immutable_t usec_immutable_fs_t:filesystem { unmount remount };
++    deepin_sec_domain_set(deepin_immutable_t);
++    domain_mcs_exemption(deepin_immutable_t);
++    domain_mls_exemption(deepin_immutable_t);
++    allow deepin_immutable_t usec_immutable_fs_t:filesystem { unmount remount };
++    allow deepin_immutable_t self:process *;
++    allow deepin_immutable_t self:dbus *;
++    allow deepin_immutable_t self:association *;
++    allow deepin_immutable_t self:packet *;
++    allow deepin_immutable_t self:fd *;
++    allow deepin_immutable_t self:key *;
++    allow deepin_immutable_t self:context *;
++    allow deepin_immutable_t self:capability *;
++    allow deepin_immutable_t self:capability2 *;
++    allow deepin_immutable_t self:cap_userns *;
++    allow deepin_immutable_t self:cap2_userns *;
++    allow deepin_immutable_t self:socket_class_set *;
++    allow deepin_immutable_t self:socket *;
++    allow deepin_immutable_t self:key_socket *;
++    allow deepin_immutable_t self:filesystem *;
++    allow deepin_immutable_t self:system *;
++    allow deepin_immutable_t self:service *;
++    allow deepin_immutable_t self:dir_file_class_set *;
++    allow deepin_immutable_t self:{ sem msg msgq shm ipc } *;
++    allow deepin_immutable_t self:nscd *;
++    allow deepin_immutable_t self:passwd *;
++    allow deepin_immutable_t self:bpf *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:process *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:fd *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:key *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:key_socket *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:socket_class_set *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:{ sem msg msgq shm ipc } *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:association *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:dbus { acquire_svc send_msg };
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:dir_file_class_set *;
++    allow deepin_immutable_t { deepin_executable_file_type unlabeled_t }:system *;
++    allow deepin_immutable_t ipsec_spd_type:association *;
++    allow deepin_immutable_t port_type:{ tcp_socket udp_socket rawip_socket sctp_socket } *;
++    allow deepin_immutable_t { packet_type unlabeled_t }:packet *;
++    allow deepin_immutable_t { node_type unlabeled_t }:node *;
++    allow deepin_immutable_t { netif_type unlabeled_t }:netif *;
++    allow deepin_immutable_t { file_type filesystem_type proc_type sysctl_type }:dir_file_class_set *;
++    allow deepin_immutable_t device_node:dir_file_class_set *;
++    allow deepin_immutable_t { filesystem_type unlabeled_t }:filesystem *;
++    allow deepin_immutable_t { file_type deepin_file_type }:service *;
++    allow deepin_immutable_t security_t:security *;
++    allow deepin_immutable_t file_type:system *;
++    allow deepin_immutable_t deepin_file_type:filesystem *;
++    allow deepin_immutable_t deepin_file_type:dir_file_class_set *;
++    allow deepin_immutable_t deepin_executable_file_type:dir_file_class_set *;
 +
-+        type_transition deepin_immutable_t deepin_usec_t:process deepin_immutable_t;
-+        allow deepin_perm_manager_sidtwo_t usec_immutable_fs_t:filesystem { unmount remount };
-+        neverallow { apt_t dpkg_t } deepin_immutable_t:process { transition dyntransition };
++    type_transition deepin_immutable_t deepin_usec_t:process deepin_immutable_t;
++    allow deepin_perm_manager_sidtwo_t usec_immutable_fs_t:filesystem { unmount remount };
 +
++    deepin_app_domain_set(deepin_unkillable_t);
++    allow deepin_unkillable_t self:service *;
++    allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
++    allow deepin_usec_t deepin_unkillable_t:service ~{ stop disable };
 +
-+        deepin_app_domain_set(deepin_unkillable_t);
-+        allow deepin_unkillable_t self:service *;
-+        allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
-+        allow deepin_usec_t deepin_unkillable_t:service ~{ stop reload disable };
++    # 系统进程deepin_system_service_t，允许其杀deepin_unkillable_t防杀进程
++    # 例如lastrore-daemon结束系统升级,需要会杀死deepin_immutable_ctl来结束系统升级
 +
-+        # 系统进程deepin_system_service_t，允许其杀deepin_unkillable_t防杀进程
-+        # 例如lastrore-daemon结束系统升级,需要会杀死deepin_immutable_ctl来结束系统升级
-+
-+        deepin_app_domain_set(deepin_system_service_t);
-+        allow deepin_system_service_t deepin_unkillable_t:process *;
-+        allow deepin_system_service_t deepin_unkillable_t:service *;
-+        allow deepin_system_service_t deepin_immutable_t:process *;
-+        allow deepin_system_service_t deepin_immutable_t:service *;
++    deepin_app_domain_set(deepin_system_service_t);
++    allow deepin_system_service_t deepin_immutable_t:process *;
++    allow deepin_system_service_t deepin_immutable_t:service *;
++    allow deepin_system_service_t deepin_unkillable_t:process *;
++    allow deepin_system_service_t deepin_unkillable_t:service *;
++    allow deepin_system_service_t deepin_usec_t:process *;
++    allow deepin_system_service_t deepin_usec_t:service *;
++    allow deepin_system_service_t apt_t:process *;
++    allow deepin_system_service_t dpkg_t:process *;
 +')


### PR DESCRIPTION
deepin_immutable_t op deepin_ro_file_t... denied

Change-Id: I34b868b3b3ed52c1577853de0d6b134f8920070d

## Summary by Sourcery

Update SELinux policy to resolve denied operations by deepin_system_service_t when interacting with immutable and package-related types.

Bug Fixes:
- Allow deepin_system_service_t to send signals and perform operations on dpkt_t and apt_t processes
- Permit deepin_system_service_t to access deepin_immutable_t and deepin_ro_file_t contexts to eliminate SELinux denials