### PR TITLE
fix: correctly install debian/post*、pre* scripts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+refpolicy (2:2.20240723-2deepin18) unstable; urgency=medium
+
+  * correctly install debian/post*、pre* scripts.
+
+ -- zhouzilong <zhouzilong@uniontech.com>  Tue, 10 Mar 2026 11:10:40 +0800
+
 refpolicy (2:2.20240723-2deepin17) unstable; urgency=medium
 
   * manage usec policy using the usec toolset.

--- a/debian/rules
+++ b/debian/rules
@@ -60,9 +60,11 @@ override_dh_clean:
 	dh_clean
 	$(MAKE) bare
 	for flavour in $(FLAVOURS) ; do \
-	  rm -f $(CURDIR)/debian/selinux-policy-$$flavour.preinst; \
-	  rm -f $(CURDIR)/debian/selinux-policy-$$flavour.postinst; \
-	  rm -f $(CURDIR)/debian/selinux-policy-$$flavour.postrm; \
+	  if [ "$$flavour" != "usec" ]; then \
+	    rm -f $(CURDIR)/debian/selinux-policy-$$flavour.preinst; \
+	    rm -f $(CURDIR)/debian/selinux-policy-$$flavour.postinst; \
+	    rm -f $(CURDIR)/debian/selinux-policy-$$flavour.postrm; \
+	  fi; \
 	  rm -rf $(CURDIR)/debian/build-$$flavour; \
 	  rm -f build-$$flavour-policy; \
 	  rm -f install-$$flavour-policy; \


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure Debian pre/post maintainer scripts are correctly installed during package builds.