### PR TITLE
fix: allow unkillable service security_t compute_av.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+refpolicy (2:2.20240723-2deepin19) unstable; urgency=medium
+
+  * fix: allow unkillable service security_t compute_av.
+
+ -- zhangya <zhangya@uniontech.com>  Thu, 28 May 2026 23:34:40 +0800
+
 refpolicy (2:2.20240723-2deepin18) unstable; urgency=medium
 
   * correctly install debian/post*、pre* scripts.

--- a/debian/patches/0001-fix-immutable.patch
+++ b/debian/patches/0001-fix-immutable.patch
@@ -38,7 +38,7 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
  
  allow deepin_executable_file_type self:file { exec_file_perms link execmod };
  
-@@ -868,31 +872,87 @@ allow deepin_home_sec_t self:filesystem
+@@ -868,31 +872,88 @@ allow deepin_home_sec_t self:filesystem
  allow deepin_executable_file_type deepin_home_sec_t:file ~{ relabelfrom relabelto };
  allow deepin_executable_file_type deepin_home_sec_t:dir list_dir_perms;
  
@@ -137,6 +137,7 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
 +
 +    deepin_app_domain_set(deepin_unkillable_t);
 +    allow deepin_unkillable_t self:service *;
++    allow deepin_unkillable_t security_t:security {compute_av};
 +    allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
 +    allow deepin_usec_t deepin_unkillable_t:service ~{ stop disable };
 +


### PR DESCRIPTION
Change-Id: I43e990ad272ad05a0b40347272985b1a1b839bde

## Summary by Sourcery

Update Debian packaging metadata and existing patch file without changing functional behavior.

Chores:
- Adjust Debian changelog entry.
- Touch up the existing immutable-related Debian patch file without altering its semantics.