### PR TITLE
fix: usec: denied deepin_unkillable_t socket create.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+refpolicy (2:2.20240723-2deepin20) unstable; urgency=medium
+
+  * fix: usec: denied deepin_unkillable_t socket create.
+
+ -- zhangya <zhangya@uniontech.com>  Wed, 24 Jun 2026 10:13:49 +0800
+
 refpolicy (2:2.20240723-2deepin19) unstable; urgency=medium
 
   * fix: allow unkillable service security_t compute_av.

--- a/debian/patches/0001-fix-immutable.patch
+++ b/debian/patches/0001-fix-immutable.patch
@@ -38,7 +38,7 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
  
  allow deepin_executable_file_type self:file { exec_file_perms link execmod };
  
-@@ -868,31 +872,88 @@ allow deepin_home_sec_t self:filesystem
+@@ -868,31 +872,93 @@ allow deepin_home_sec_t self:filesystem
  allow deepin_executable_file_type deepin_home_sec_t:file ~{ relabelfrom relabelto };
  allow deepin_executable_file_type deepin_home_sec_t:dir list_dir_perms;
  
@@ -138,6 +138,11 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
 +    deepin_app_domain_set(deepin_unkillable_t);
 +    allow deepin_unkillable_t self:service *;
 +    allow deepin_unkillable_t security_t:security {compute_av};
++    allow deepin_unkillable_t self:socket *;
++    allow deepin_unkillable_t self:fd *;
++    allow deepin_unkillable_t self:key_socket *;
++    allow deepin_unkillable_t self:key *;
++    allow deepin_unkillable_t self:context *;
 +    allow deepin_usec_t deepin_unkillable_t:process ~{ setcurrent setexec sigkill signal sigstop };
 +    allow deepin_usec_t deepin_unkillable_t:service ~{ stop disable };
 +


### PR DESCRIPTION
Change-Id: Ie1715c7d7ad5fd992a95705a683b075eef3c4cd5

## Summary by Sourcery

Update Debian packaging changelog and immutable patch metadata for the usec policy fix.

Enhancements:
- Adjust Debian changelog entries to reflect the latest SELinux policy changes.
- Refresh the immutable patch file to align with current packaging requirements.