### PR TITLE
feat: filearmor默认策略迁移到usec

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+refpolicy (2:2.20240723-2deepin21) unstable; urgency=medium
+
+  * feat: usec: replace filearmor default policy with usec policy 
+
+ -- chenxuanlin <chenxuanlin@uniontech.com>  Fri, 21 Aug 2026 17:13:49 +0800
+
 refpolicy (2:2.20240723-2deepin20) unstable; urgency=medium
 
   * fix: usec: denied deepin_unkillable_t socket create.

--- a/debian/patches/0003-filearmor-policy-migrate.patch
+++ b/debian/patches/0003-filearmor-policy-migrate.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: security <security@uniontech.com>
+Date: Fri, 14 Aug 2026 00:00:00 +0800
+Subject: [PATCH] filearmor policy migrate to usec
+
+Migrate /var/uos/.license.xkey and /etc/apt/auth.conf.d/uos.conf
+filearmor protection to usec (SELinux) policy.
+
+---
+ policy/modules/services/deepin_perm_control.fc | 2 ++
+ policy/modules/services/deepin_perm_control.te | 32 ++++++++++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+)
+
+Index: refpolicy/policy/modules/services/deepin_perm_control.fc
+===================================================================
+--- refpolicy.orig/policy/modules/services/deepin_perm_control.fc
++++ refpolicy/policy/modules/services/deepin_perm_control.fc
+@@ -9,3 +9,5 @@
+ /usr/sbin/deepin-security-enhance   --   gen_context(system_u:object_r:deepin_security_enhance_exec_t,s0)
+ /home/\.sec    -d   gen_context(system_u:object_r:deepin_home_sec_t,s0)
+ /home/\.sec(/.*)?   gen_context(system_u:object_r:deepin_home_sec_t,s0)
++/etc/apt/auth\.conf\.d/uos\.conf   --   gen_context(system_u:object_r:deepin_ro_file_t,s0)
++/var/uos/\.license\.xkey           --   gen_context(system_u:object_r:deepin_ro_file_t,s0)
+Index: refpolicy/policy/modules/services/deepin_perm_control.te
+===================================================================
+--- refpolicy.orig/policy/modules/services/deepin_perm_control.te
++++ refpolicy/policy/modules/services/deepin_perm_control.te
+@@ -962,3 +962,35 @@
+     allow deepin_system_service_t apt_t:process *;
+     allow deepin_system_service_t dpkg_t:process *;
+ ')
++
++ifdef(`enable_usec',`
++    # ======== filearmor 策略迁移至 usec ========
++    # 核心文件(/var/uos/.license.xkey、/etc/apt/auth.conf.d/uos.conf)写权限域
++    attribute deepin_corefile_writable_domain;
++
++    # 原 filearmor 白名单中落默认域 deepin_usec_t 的应用，新建专用域
++    type deepin_activator_t;
++    deepin_app_domain_set(deepin_activator_t)
++    typeattribute deepin_activator_t deepin_corefile_writable_domain;
++
++    type deepin_license_agent_t;
++    deepin_app_domain_set(deepin_license_agent_t)
++    typeattribute deepin_license_agent_t deepin_corefile_writable_domain;
++
++    type deepin_service_support_t;
++    deepin_app_domain_set(deepin_service_support_t)
++    typeattribute deepin_service_support_t deepin_corefile_writable_domain;
++
++    type deepin_daemon_t;
++    deepin_app_domain_set(deepin_daemon_t)
++    typeattribute deepin_daemon_t deepin_corefile_writable_domain;
++
++    # 已有独立域的白名单应用显式纳入
++    typeattribute deepin_immutable_t deepin_corefile_writable_domain;
++    typeattribute deepin_perm_manager_sidtwo_t deepin_corefile_writable_domain;
++    typeattribute apt_t deepin_corefile_writable_domain;
++    typeattribute dpkg_t deepin_corefile_writable_domain;
++
++    # 核心文件写权限(filearmor rwxd 等价)
++    allow deepin_corefile_writable_domain deepin_ro_file_t:file { read_file_perms setattr_file_perms write_file_perms };
++')

--- a/debian/patches/0003-filearmor-policy-migrate.patch
+++ b/debian/patches/0003-filearmor-policy-migrate.patch
@@ -8,34 +8,40 @@ filearmor protection to usec (SELinux) policy.
 
 ---
  policy/modules/services/deepin_perm_control.fc | 2 ++
- policy/modules/services/deepin_perm_control.te | 32 ++++++++++++++++++++++++++++++++
- 2 files changed, 34 insertions(+)
+ policy/modules/services/deepin_perm_control.te | 36 ++++++++++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
 
 Index: refpolicy/policy/modules/services/deepin_perm_control.fc
 ===================================================================
 --- refpolicy.orig/policy/modules/services/deepin_perm_control.fc
 +++ refpolicy/policy/modules/services/deepin_perm_control.fc
-@@ -9,3 +9,5 @@
+@@ -9,3 +9,7 @@
  /usr/sbin/deepin-security-enhance   --   gen_context(system_u:object_r:deepin_security_enhance_exec_t,s0)
  /home/\.sec    -d   gen_context(system_u:object_r:deepin_home_sec_t,s0)
  /home/\.sec(/.*)?   gen_context(system_u:object_r:deepin_home_sec_t,s0)
-+/etc/apt/auth\.conf\.d/uos\.conf   --   gen_context(system_u:object_r:deepin_ro_file_t,s0)
-+/var/uos/\.license\.xkey           --   gen_context(system_u:object_r:deepin_ro_file_t,s0)
++ifdef(`enable_usec',`
++/etc/apt/auth\.conf\.d/uos\.conf   --   gen_context(system_u:object_r:deepin_uos_auth_conf_t,s0)
++/var/uos/\.license\.xkey           --   gen_context(system_u:object_r:deepin_license_xkey_t,s0)
++')
 Index: refpolicy/policy/modules/services/deepin_perm_control.te
 ===================================================================
 --- refpolicy.orig/policy/modules/services/deepin_perm_control.te
 +++ refpolicy/policy/modules/services/deepin_perm_control.te
-@@ -962,3 +962,35 @@
+@@ -962,3 +962,39 @@
      allow deepin_system_service_t apt_t:process *;
      allow deepin_system_service_t dpkg_t:process *;
  ')
 +
 +ifdef(`enable_usec',`
-+    # ======== filearmor 策略迁移至 usec ========
-+    # 核心文件(/var/uos/.license.xkey、/etc/apt/auth.conf.d/uos.conf)写权限域
 +    attribute deepin_corefile_writable_domain;
++    type deepin_uos_auth_conf_t;
++    deepin_file_type_set(deepin_uos_auth_conf_t)
++    deepin_readable_file_type_set(deepin_uos_auth_conf_t)
 +
-+    # 原 filearmor 白名单中落默认域 deepin_usec_t 的应用，新建专用域
++    type deepin_license_xkey_t;
++    deepin_file_type_set(deepin_license_xkey_t)
++    deepin_readable_file_type_set(deepin_license_xkey_t)
++
 +    type deepin_activator_t;
 +    deepin_app_domain_set(deepin_activator_t)
 +    typeattribute deepin_activator_t deepin_corefile_writable_domain;
@@ -58,6 +64,6 @@ Index: refpolicy/policy/modules/services/deepin_perm_control.te
 +    typeattribute apt_t deepin_corefile_writable_domain;
 +    typeattribute dpkg_t deepin_corefile_writable_domain;
 +
-+    # 核心文件写权限(filearmor rwxd 等价)
-+    allow deepin_corefile_writable_domain deepin_ro_file_t:file { read_file_perms setattr_file_perms write_file_perms };
++    allow deepin_corefile_writable_domain deepin_uos_auth_conf_t:file { read_file_perms setattr_file_perms write_file_perms };
++    allow deepin_corefile_writable_domain deepin_license_xkey_t:file { read_file_perms setattr_file_perms write_file_perms };
 +')

--- a/debian/patches/0004-usec-ac-manager-policy-dirs.patch
+++ b/debian/patches/0004-usec-ac-manager-policy-dirs.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: security <security@uniontech.com>
+Date: Wed, 19 Aug 2026 00:00:00 +0800
+Subject: [PATCH] protect usec-ac-manager policy directories on usec path
+
+Add dedicated usec policy for:
+- /var/lib/uos/usec
+- /usr/share/uos/usec
+- /etc/uos/usec
+
+---
+ policy/modules/services/deepin_perm_control.fc | 6 ++++++
+ policy/modules/services/deepin_perm_control.te | 10 ++++++++++
+ 2 files changed, 16 insertions(+)
+
+Index: refpolicy/policy/modules/services/deepin_perm_control.fc
+===================================================================
+--- refpolicy.orig/policy/modules/services/deepin_perm_control.fc
++++ refpolicy/policy/modules/services/deepin_perm_control.fc
+@@ -12,4 +12,10 @@ ifdef(`enable_usec',`
+ /etc/apt/auth\.conf\.d/uos\.conf   --   gen_context(system_u:object_r:deepin_uos_auth_conf_t,s0)
+ /var/uos/\.license\.xkey           --   gen_context(system_u:object_r:deepin_license_xkey_t,s0)
++/var/lib/uos/usec                    -d   gen_context(system_u:object_r:deepin_uos_usec_policy_t,s0)
++/var/lib/uos/usec(/.*)?                   gen_context(system_u:object_r:deepin_uos_usec_policy_t,s0)
++/usr/share/uos/usec                  -d   gen_context(system_u:object_r:deepin_uos_usec_policy_t,s0)
++/usr/share/uos/usec(/.*)?                 gen_context(system_u:object_r:deepin_uos_usec_policy_t,s0)
++/etc/uos/usec                        -d   gen_context(system_u:object_r:deepin_uos_usec_policy_t,s0)
++/etc/uos/usec(/.*)?                       gen_context(system_u:object_r:deepin_uos_usec_policy_t,s0)
+ ')
+
+Index: refpolicy/policy/modules/services/deepin_perm_control.te
+===================================================================
+--- refpolicy.orig/policy/modules/services/deepin_perm_control.te
++++ refpolicy/policy/modules/services/deepin_perm_control.te
+@@ -994,3 +994,13 @@ ifdef(`enable_usec',`
+     allow deepin_corefile_writable_domain deepin_uos_auth_conf_t:file { read_file_perms setattr_file_perms write_file_perms };
+     allow deepin_corefile_writable_domain deepin_license_xkey_t:file { read_file_perms setattr_file_perms write_file_perms };
+ ')
++
++ifdef(`enable_usec',`
++    type deepin_uos_usec_policy_t;
++    deepin_file_type_set(deepin_uos_usec_policy_t)
++    deepin_readable_file_type_set(deepin_uos_usec_policy_t)
++
++    allow { deepin_perm_manager_sidtwo_t deepin_immutable_t dpkg_t sysadm_t security_t } deepin_uos_usec_policy_t:dir manage_dir_perms;
++    allow { deepin_perm_manager_sidtwo_t deepin_immutable_t dpkg_t sysadm_t security_t } deepin_uos_usec_policy_t:file manage_file_perms;
++    allow { deepin_perm_manager_sidtwo_t deepin_immutable_t dpkg_t sysadm_t security_t } deepin_uos_usec_policy_t:lnk_file manage_lnk_file_perms;
++')

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -22,3 +22,4 @@ support-v25-usec-policy.patch
 initialize-usids-of-usec-policy.patch
 0001-fix-immutable.patch
 0003-filearmor-policy-migrate.patch
+0004-usec-ac-manager-policy-dirs.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ support-v25-usec-policy.patch
 0001-deepin-fix-application-antiunloading-bug.patch
 initialize-usids-of-usec-policy.patch
 0001-fix-immutable.patch
+0003-filearmor-policy-migrate.patch


### PR DESCRIPTION
## Summary by Sourcery

Migrate FileArmor’s default policy configuration to usec and update the Debian packaging accordingly.

Enhancements:
- Migrate the default FileArmor policy and access-control manager policy directories to usec.

Build:
- Add Debian packaging patches and register them in the patch series.